### PR TITLE
Actualizaciones en base a ckanext-harvest

### DIFF
--- a/ckanext/dkan/harvesters/dkanharvester.py
+++ b/ckanext/dkan/harvesters/dkanharvester.py
@@ -51,7 +51,7 @@ class DKANHarvester(HarvesterBase):
         return '%s/current_package_list_with_resources' % self._get_action_api_offset()
 
     def _get_content(self, url):
-        http_request = urllib2.Request(url=url)
+        http_request = urllib2.Request(url=url, timeout=90)
 
         api_key = self.config.get('api_key')
         if api_key:

--- a/ckanext/dkan/harvesters/dkanharvester.py
+++ b/ckanext/dkan/harvesters/dkanharvester.py
@@ -51,14 +51,14 @@ class DKANHarvester(HarvesterBase):
         return '%s/current_package_list_with_resources' % self._get_action_api_offset()
 
     def _get_content(self, url):
-        http_request = urllib2.Request(url=url, timeout=90)
+        http_request = urllib2.Request(url=url)
 
         api_key = self.config.get('api_key')
         if api_key:
             http_request.add_header('Authorization', api_key)
 
         try:
-            http_response = urllib2.urlopen(http_request)
+            http_response = urllib2.urlopen(http_request, timeout=90)
         except urllib2.HTTPError, e:
             if e.getcode() == 404:
                 raise ContentNotFoundError('HTTP error: %s' % e.code)
@@ -727,6 +727,19 @@ class DKANHarvester(HarvesterBase):
         package_dict['tags'] = tags
 
         return package_dict
+
+
+class ContentFetchError(Exception):
+    pass
+
+
+class ContentNotFoundError(ContentFetchError):
+    pass
+
+
+class RemoteResourceError(Exception):
+    pass
+
 
 class SearchError(Exception):
     pass

--- a/ckanext/dkan/harvesters/dkanharvester.py
+++ b/ckanext/dkan/harvesters/dkanharvester.py
@@ -6,7 +6,7 @@ import datetime
 import socket
 import datetime
 
-from ckanext.harvest.harvesters import CKANHarvester
+from ckanext.harvest.harvesters.ckanharvester import CKANHarvester
 from ckanext.harvest.model import HarvestObject
 from ckan.logic import ValidationError, NotFound, get_action
 from ckan import model

--- a/ckanext/dkan/harvesters/dkanharvester.py
+++ b/ckanext/dkan/harvesters/dkanharvester.py
@@ -242,7 +242,7 @@ class DKANHarvester(HarvesterBase):
 
         # Ideally we can request from the remote CKAN only those datasets
         # modified since the last completely successful harvest.
-        last_error_free_job = self._last_error_free_job(harvest_job)
+        last_error_free_job = self.last_error_free_job(harvest_job)
         log.debug('Last error-free job: %r', last_error_free_job)
         if (last_error_free_job and
                 not self.config.get('force_all', False)):


### PR DESCRIPTION
Se hacen las siguientes adaptaciones en base a la actualizacion de ckanext-harvest:

- Se renombra metodo _last_error_free_job por last_error_free_job
- Se implementa la interfaz del BaseHarvest en lugar de CKANHarvest como el base.
- Se aumenta el tiempo de espera para dar timeout en la peticion a una fuente.
- Se implementan Handlers para excepciones necesarias.